### PR TITLE
:hammer: Wayland support for electron apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,10 @@ You may use the following environment variables to change the behaviour of the i
 * `FLATPAK_ISOLATE_PIP` (= `FLATPAK_ISOLATE_PACKAGES`)
 
 * `FLATPAK_PREFER_USER_PIP` (= `FLATPAK_PREFER_USER_PACKAGES`)
+
+* `EDITOR_RUNTIME_ARGS`
+
+  Add custom arguments to the editor. 
+  
+  Example `flatpak override --user --env=EDITOR_RUNTIME_ARGS="CUSTOM_ARGS" ...`
+

--- a/editor.sh
+++ b/editor.sh
@@ -11,7 +11,7 @@ function display_server_args (){
   # See https://github.com/flathub/im.riot.Riot/blob/3fdd41c84f40fa1e8e186bade5d832d79045600c/element.sh
   # See also https://gaultier.github.io/blog/wayland_from_scratch.html 
   # and https://github.com/flathub/com.vscodium.codium/issues/321
-  if [ "wayland" == "${XDG_DISPLAY_TYPE}" ] && [ -n "${WAYLAND_DISPLAY}" ]
+  if [ "wayland" == "${XDG_SESSION_TYPE}" ] && [ -n "${WAYLAND_DISPLAY}" ]
   then
     if [[ "${WAYLAND_DISPLAY}" =~ ^/ ]]
     then

--- a/editor.sh
+++ b/editor.sh
@@ -11,18 +11,15 @@ function display_server_args (){
   # See https://github.com/flathub/im.riot.Riot/blob/3fdd41c84f40fa1e8e186bade5d832d79045600c/element.sh
   # See also https://gaultier.github.io/blog/wayland_from_scratch.html 
   # and https://github.com/flathub/com.vscodium.codium/issues/321
-  if [ "wayland" == "${XDG_SESSION_TYPE}" ] && [ -n "${WAYLAND_DISPLAY}" ]
-  then
-    if [[ "${WAYLAND_DISPLAY}" =~ ^/ ]]
-    then
+  if [ "wayland" == "${XDG_SESSION_TYPE}" ] && [ -n "${WAYLAND_DISPLAY}" ]; then
+    if [[ "${WAYLAND_DISPLAY}" =~ ^/ ]]; then
       wayland_socket="${WAYLAND_DISPLAY}"
     else
       wayland_socket="${XDG_RUNTIME_DIR:-/run/user/${UID}}/${WAYLAND_DISPLAY}"
     fi
   fi
 
-  if [ -e "$wayland_socket" ]
-  then
+  if [ -e "$wayland_socket" ]; then
     DISPLAY_SERVER_ARGS="--ozone-platform=wayland --enable-wayland-ime --enable-features=WaylandWindowDecorations"
     [ -c /dev/nvidia0 ] && DISPLAY_SERVER_ARGS="${DISPLAY_SERVER_ARGS} --disable-gpu-sandbox"
   else

--- a/editor.sh
+++ b/editor.sh
@@ -11,16 +11,24 @@ function display_server_args (){
   # See https://github.com/flathub/im.riot.Riot/blob/3fdd41c84f40fa1e8e186bade5d832d79045600c/element.sh
   # See also https://gaultier.github.io/blog/wayland_from_scratch.html 
   # and https://github.com/flathub/com.vscodium.codium/issues/321
-  if [[ ${WAYLAND_DISPLAY} == "/run/flatpak/wayland-"* ]] || [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]] && [[ "wayland" == "${XDG_SESSION_TYPE}" ]]
+  if [ "wayland" == "${XDG_DISPLAY_TYPE}" ] && [ -n "${WAYLAND_DISPLAY}" ]
   then
-      DISPLAY_SERVER_ARGS="--ozone-platform-hint=auto --enable-wayland-ime --enable-features=WaylandWindowDecorations"
-      if  [ -c /dev/nvidia0 ]
-      then
-          DISPLAY_SERVER_ARGS="${DISPLAY_SERVER_ARGS} --disable-gpu-sandbox" 
-      fi
-  else
-      DISPLAY_SERVER_ARGS="--ozone-platform=x11"
+    if [[ "${WAYLAND_DISPLAY}" =~ ^/ ]]
+    then
+      wayland_socket="${WAYLAND_DISPLAY}"
+    else
+      wayland_socket="${XDG_RUNTIME_DIR:-/run/user/${UID}}/${WAYLAND_DISPLAY}"
+    fi
   fi
+
+  if [ -e "$wayland_socket" ]
+  then
+    DISPLAY_SERVER_ARGS="--ozone-platform=wayland --enable-wayland-ime --enable-features=WaylandWindowDecorations"
+    [ -c /dev/nvidia0 ] && DISPLAY_SERVER_ARGS="${DISPLAY_SERVER_ARGS} --disable-gpu-sandbox"
+  else
+    DISPLAY_SERVER_ARGS="--ozone-platform=x11"
+  fi
+
   echo "${DISPLAY_SERVER_ARGS}"
 }
 

--- a/editor.sh
+++ b/editor.sh
@@ -9,7 +9,9 @@ SDK_UPDATE="${XDG_CONFIG_HOME}/@FLAGFILE_PREFIX@-sdk-update-@SDK_VERSION@"
 
 function display_server_args (){
   # See https://github.com/flathub/im.riot.Riot/blob/3fdd41c84f40fa1e8e186bade5d832d79045600c/element.sh
-  if [ "wayland" == "${XDG_SESSION_TYPE}" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]
+  # See also https://gaultier.github.io/blog/wayland_from_scratch.html 
+  # and https://github.com/flathub/com.vscodium.codium/issues/321
+  if [[ ${WAYLAND_DISPLAY} == "/run/flatpak/wayland-"* ]] || [[ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]] && [[ "wayland" == "${XDG_SESSION_TYPE}" ]]
   then
       DISPLAY_SERVER_ARGS="--ozone-platform-hint=auto --enable-wayland-ime --enable-features=WaylandWindowDecorations"
       if  [ -c /dev/nvidia0 ]
@@ -24,8 +26,8 @@ function display_server_args (){
 
 function exec_editor() {
   @EXPORT_ENVS@
-  # shellcheck disable=SC2046
-  exec "@WRAPPER_PATH@" @EDITOR_ARGS@ $(display_server_args) "$@"
+  # shellcheck disable=SC2046,SC2086
+  exec "@WRAPPER_PATH@" @EDITOR_ARGS@ $(display_server_args) ${EDITOR_RUNTIME_ARGS} "$@"
 }
 
 if [ ! -f "${FIRST_RUN}" ]; then

--- a/editor.sh
+++ b/editor.sh
@@ -7,9 +7,25 @@ shopt -s nullglob
 FIRST_RUN="${XDG_CONFIG_HOME}/@FLAGFILE_PREFIX@-first-run"
 SDK_UPDATE="${XDG_CONFIG_HOME}/@FLAGFILE_PREFIX@-sdk-update-@SDK_VERSION@"
 
+function display_server_args (){
+  # See https://github.com/flathub/im.riot.Riot/blob/3fdd41c84f40fa1e8e186bade5d832d79045600c/element.sh
+  if [ "wayland" == "${XDG_SESSION_TYPE}" ] && [ -e "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]
+  then
+      DISPLAY_SERVER_ARGS="--ozone-platform-hint=auto --enable-wayland-ime --enable-features=WaylandWindowDecorations"
+      if  [ -c /dev/nvidia0 ]
+      then
+          DISPLAY_SERVER_ARGS="${DISPLAY_SERVER_ARGS} --disable-gpu-sandbox" 
+      fi
+  else
+      DISPLAY_SERVER_ARGS="--ozone-platform=x11"
+  fi
+  echo "${DISPLAY_SERVER_ARGS}"
+}
+
 function exec_editor() {
   @EXPORT_ENVS@
-  exec "@WRAPPER_PATH@" @EDITOR_ARGS@ "$@"
+  # shellcheck disable=SC2046
+  exec "@WRAPPER_PATH@" @EDITOR_ARGS@ $(display_server_args) "$@"
 }
 
 if [ ! -f "${FIRST_RUN}" ]; then


### PR DESCRIPTION
if `socket=wayland` is active the parameters to handle wayland decorations is set also `ozone-platform-hint=auto` is set

if you override with `nosocket=wayland` force `ozone-platform=x11`