### PR TITLE
Enable text-input-v3 support for electron wayland

### DIFF
--- a/editor.sh
+++ b/editor.sh
@@ -31,6 +31,7 @@ function update_display_server_args () {
       "--ozone-platform=wayland"
       "--enable-wayland-ime"
       "--enable-features=WaylandWindowDecorations"
+      "--wayland-text-input-version=3"
     )
     if [ -c /dev/nvidia0 ]; then
       DISPLAY_SERVER_ARGS+=("--disable-gpu-sandbox")


### PR DESCRIPTION
In the latest version of electron (version 33, chrome M130) the new command line flag will enable text-input-v3 in electron app, allowing the use of IME in DEs that doesn't support the deprecated text-input-v1, including Gnome.